### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,15 @@
 {
-    "recommendations": [
-        "yzhang.markdown-all-in-one",
-        "redhat.vscode-yaml",
-        "akamud.vscode-caniuse",
-        "visualstudioexptteam.intellicode-api-usage-examples",
-        "pflannery.vscode-versionlens",
-        "christian-kohler.npm-intellisense",
-        "esbenp.prettier-vscode",
-        "eamodio.gitlens",
-        "github.vscode-pull-request-github",
-        "github.vscode-github-actions",
-        "GitHub.copilot"
-    ]
+  "recommendations": [
+    "yzhang.markdown-all-in-one",
+    "redhat.vscode-yaml",
+    "akamud.vscode-caniuse",
+    "visualstudioexptteam.intellicode-api-usage-examples",
+    "legalfina.npm-version-lens",
+    "christian-kohler.npm-intellisense",
+    "esbenp.prettier-vscode",
+    "eamodio.gitlens",
+    "github.vscode-pull-request-github",
+    "github.vscode-github-actions",
+    "GitHub.copilot"
+  ]
 }


### PR DESCRIPTION
[![PR-41](https://img.shields.io/badge/GitHub.dev-PR--41-blue?logo=visualstudio)](https://github.dev/EasyWebApp/WebCell/pull/41) [![PR-41](https://img.shields.io/badge/GitHub_codespaces-PR--41-black?logo=github)](https://codespaces.new/EasyWebApp/WebCell/pull/41) [![PR-41](https://img.shields.io/badge/GitPod.io-PR--41-orange?logo=git)](https://gitpod.io/?autostart=true#https://github.com/EasyWebApp/WebCell/pull/41) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=EasyWebApp&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens 